### PR TITLE
Reverted String Class .to_a monkey patch

### DIFF
--- a/lib/opl.rb
+++ b/lib/opl.rb
@@ -563,7 +563,7 @@ class OPL
 			data_string = data_hash_string.gsub("{",",").gsub("}",",")
 			names = data_string.scan(/,[a-z]/).map{|comma_name|comma_name.gsub(",","")}
 			string_values = data_string.scan(/\=\>[\[\d\.\]\,\-]+,/).map{|scanned_value|scanned_value[2..-2]}
-			values = string_values.map{|sv|sv.to_a}
+			values = string_values.map{|sv|sv.to_array}
 			data_hash = {}
 			names.each_index do |i|
 				name = names[i]

--- a/lib/string.rb
+++ b/lib/string.rb
@@ -58,10 +58,6 @@ class String
 		end
 	end
 
-	def to_a
-		self.to_array
-	end
-
 	def index_array(str)
 		indices = []
 		string = self


### PR DESCRIPTION
.to_a method has been removed from the String class since Ruby 1.9 reference: https://stackoverflow.com/a/4465629/12131035
Rails caching code works with the assumption that .to_a can not be called on strings. 

The following snippet below in the file Activesupport-6.0.3.2/lib/active_support/cache.rb, ends up in infinite recursion is .to_a method is called on Strings.

def expanded_version(key)
          case
          when key.respond_to?(:cache_version) then key.cache_version.to_param
          when key.is_a?(Array)                then key.map { |element| expanded_version(element) }.compact.to_param
          when key.respond_to?(:to_a)          then expanded_version(key.to_a)
          end
        end

This change is needed to ensure that rails and ruby code works as intended.